### PR TITLE
Free Winring0 patch

### DIFF
--- a/cpucounters.cpp
+++ b/cpucounters.cpp
@@ -112,7 +112,7 @@ bool PCM::initWinRing0Lib()
 
     if (result == FALSE)
     {
-        CloseHandle(hOpenLibSys);
+        FreeLibrary(hOpenLibSys);
         hOpenLibSys = NULL;
         return false;
     }


### PR DESCRIPTION
CloseHandle can not free the library.